### PR TITLE
Fix running on Xcode 14.1

### DIFF
--- a/ios/Keys.mm
+++ b/ios/Keys.mm
@@ -10,7 +10,7 @@
   + (NSString *)secureFor: (NSString *)key {
       @try {
           NSString* stringfyData = [NSString stringWithCString:Crypto().getJniJsonStringyfyData(privateKey).c_str() encoding:[NSString defaultCStringEncoding]];
-          NSLog(stringfyData);
+          NSLog(@"%@", stringfyData);
           NSData *data = [stringfyData dataUsingEncoding:NSUTF8StringEncoding];
           NSMutableDictionary *s = [NSJSONSerialization JSONObjectWithData:data options:0 error:NULL];
           NSString *value =[s objectForKey:key];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-keys",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "secure keys through jni",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/src/util/keysFilesTemplateIos.js
+++ b/src/util/keysFilesTemplateIos.js
@@ -80,7 +80,7 @@ module.exports.makeKeysPackageMMTemplateIOS = (key) => {
   + (NSString *)secureFor: (NSString *)key {
       @try {
           NSString* stringfyData = [NSString stringWithCString:Crypto().getJniJsonStringyfyData(privateKey).c_str() encoding:[NSString defaultCStringEncoding]];
-          NSLog(stringfyData);
+          NSLog(@"%@", stringfyData);
           NSData *data = [stringfyData dataUsingEncoding:NSUTF8StringEncoding];
           NSMutableDictionary *s = [NSJSONSerialization JSONObjectWithData:data options:0 error:NULL];
           NSString *value =[s objectForKey:key];


### PR DESCRIPTION
- Remove Warning: Format string is not a string literal (potentially insecure)