### PR TITLE
fix(flavor): get properly flavor for assemble and bundle build

### DIFF
--- a/android/RNKeys.gradle
+++ b/android/RNKeys.gradle
@@ -5,11 +5,18 @@ import java.util.regex.Pattern
 
 def getCurrentFlavor() {
   Gradle gradle = getGradle()
+  String taskName = gradle.getStartParameter().getTaskNames()[0]
 
   // match optional modules followed by the task
   // (?:.*:)* is a non-capturing group to skip any :foo:bar: if they exist
   // *[a-z]+([A-Za-z]+) will capture the flavor part of the task name onward (e.g., assembleRelease --> Release)
   def pattern = Pattern.compile("(?:.*:)*[a-z]+([A-Z][A-Za-z0-9]+)")
+
+  if (taskName?.startsWith("assemble") || taskName?.startsWith("bundle")) {
+    // e.g. if assemblestagingrelease or bundlestagingrelease then the flavor will be staging
+    pattern = Pattern.compile("(?:assemble|bundle)(\\w+)([Rr]elease|[Dd]ebug)")
+  }
+
   def flavor = ""
 
   gradle.getStartParameter().getTaskNames().any { name ->


### PR DESCRIPTION
## Summary

With the gradle fastlane plugin, we can pass a flavor sth like this:
```
gradle(
  task: "assemble",
  flavor: "staging",
  build_type: "release"
)
```
and then the task has a name such as `assemblestagingrelease`. To get the correct flavor the `RNKeys.gradle` file should be fixed.

## Changelog

[fix] [gradle] - get properly flavor for assemble and bundle build
