### PR TITLE
fix: add check for os shell in RNkeys.gradle file

### DIFF
--- a/android/RNKeys.gradle
+++ b/android/RNKeys.gradle
@@ -83,7 +83,15 @@ def loadKeys() {
       def nodeModulesDir = getNodeModulesDir()
       exportCommand = exportCommand + nodeModulesDir + "/node_modules/react-native-keys/keysAndroid.js"
     }
-    def proc = ["/bin/sh", "-c", exportCommand].execute()
+
+    def proc;
+
+    if (System.properties['os.name'].toLowerCase().contains('windows')) {
+        proc = ["cmd", "/c", exportCommand].execute()
+    } else {
+        proc = ["/bin/sh", "-c", exportCommand].execute()
+    }
+
     proc.consumeProcessOutput(System.out, System.err)
 
     println(keysFile)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
Fixes [an issue](https://github.com/numandev1/react-native-keys/issues/43#issuecomment-1683553366) where build fails on windows.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Added a check to determine os shell before executing `exportCommand` in the loadKeys function.

## Changelog

[CATEGORY] [TYPE] - Message

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
