### PR TITLE
trim KEYSFILE; remove old version of PrivateKey.java

### DIFF
--- a/src/util/common.js
+++ b/src/util/common.js
@@ -152,6 +152,7 @@ module.exports.getAndroidEnvironmentFile = () => {
 module.exports.makeFileInAndroidMainAssetsFolder = (fileContent, fileName) => {
   try {
     const filePath = path.join(ANDROID_KEYS_DIR_PATH, fileName);
+    fs.removeSync(filePath)
     fs.outputFileSync(filePath, fileContent);
     return true;
   } catch (error) {

--- a/src/util/common.js
+++ b/src/util/common.js
@@ -152,7 +152,6 @@ module.exports.getAndroidEnvironmentFile = () => {
 module.exports.makeFileInAndroidMainAssetsFolder = (fileContent, fileName) => {
   try {
     const filePath = path.join(ANDROID_KEYS_DIR_PATH, fileName);
-    fs.removeSync(filePath)
     fs.outputFileSync(filePath, fileContent);
     return true;
   } catch (error) {

--- a/src/util/common.js
+++ b/src/util/common.js
@@ -58,7 +58,7 @@ const ANDROID_KEYS_DIR_PATH = path.join(
 const PROJECT_DIRECTORY_IOS_PATH = path.join(PROJECT_ROOT_DIR_PATH, 'ios');
 
 module.exports.getKeys = (KEYS_FILE_NAME) => {
-  const jniJsonFilePath = `${PROJECT_ROOT_DIR_PATH}${KEYS_FILE_NAME}`;
+  const jniJsonFilePath = `${PROJECT_ROOT_DIR_PATH}${KEYS_FILE_NAME}`.trim();
   const keysJson = fs.readJSONSync(jniJsonFilePath);
   const secureKeys = keysJson;
   return secureKeys;
@@ -155,6 +155,7 @@ module.exports.makeFileInAndroidMainAssetsFolder = (fileContent, fileName) => {
     fs.outputFileSync(filePath, fileContent);
     return true;
   } catch (error) {
+    console.error(error)
     return false;
   }
 };


### PR DESCRIPTION
## Summary

Solves situation when keyfile env var is used without quotes, e.g. `KEYSFILE=aaa node ./cli.js` is used

## Test Plan

Tested manually