### PR TITLE
feat: support pnpm

### DIFF
--- a/src/util/common.js
+++ b/src/util/common.js
@@ -10,10 +10,10 @@ const exampleDirName =
     ? expoExampleDirName
     : 'example';
 
-const PROJECT_ROOT_DIR_PATH = path.join(
-  __dirname,
-  isExample ? `../../${exampleDirName}/` : '../../../../'
-);
+const PROJECT_ROOT_DIR_PATH = !isExample ?
+  path.join(process.env.SRCROOT ?? process.cwd(), "../") :
+  path.join(__dirname, `../../${exampleDirName}/`);
+
 const PACKAGE_ROOT_DIR_PATH = path.join(__dirname, '../../');
 const RN_KEYS_PATH = path.join('node_modules', 'react-native-keys');
 const KEYS_IOS_PATH = path.join(RN_KEYS_PATH, 'ios');

--- a/src/util/common.js
+++ b/src/util/common.js
@@ -6,8 +6,7 @@ const DEFAULT_FILE_NAME = 'keys.development.json';
 
 const expoExampleDirName = 'exampleExpo';
 const exampleDirName =
-  process.cwd().includes(expoExampleDirName) ||
-  process.env?.SRCROOT?.includes(expoExampleDirName)
+  (process.env.SRCROOT ?? process.cwd()).includes(expoExampleDirName)
     ? expoExampleDirName
     : 'example';
 


### PR DESCRIPTION
## Summary
Support pnpm package manager
(from React Native 0.73 support pnpm, but doesn't yet support this library)

## Changelog
Support pnpm package manager

## Test Plan
works properly with npm(or yarn1) and pnpm