### PR TITLE
fix: change to weaker type definitions

### DIFF
--- a/src/util/common.js
+++ b/src/util/common.js
@@ -70,20 +70,12 @@ module.exports.genTSType = (allKeys) => {
   Object.keys(allKeys?.public ?? {}).forEach((key) => {
     result += `\n  ${key}: string;`;
   });
-  if(!allKeys?.public) {
-    result += '\n [key: string]: string;\n};\n\n';
-  } else {
-    result += '\n};\n\n';
-  }
+  result += '\n [key: string]: string;\n};\n\n';
   result += 'export type KeyTurboSecuredType = {';
   Object.keys(allKeys?.secure ?? {}).forEach((key) => {
     result += `\n  ${key}: string;`;
   });
-  if(!allKeys?.secure) {
-    result += '\n [key: string]: string;\n};\n\n';
-  } else {
-    result += '\n};\n\n';
-  }
+  result += '\n [key: string]: string;\n};\n\n';
   fs.outputFileSync(path.join(SRC_PATH, 'type.ts'), result);
 };
 


### PR DESCRIPTION
## Summary
change to weaker type definitions (partial revert commit bd74375bef2a618624c77d8be1bc0354460a502a)
because current definition doesn't support below case
- dev
```json
{
  "public": {
    "OPTIONAL1": "test",
    "REQUIRE": "false"
  }
}

```
- prod
```json
{
  "public": {
    "OPTIONAL2": "test",
    "REQUIRE": "false"
  }
}
```
above case we met type error

## Changelog
change to weaker type definitions

## Test Plan
