### PR TITLE
fix: Ensure correct ABI filtering in CMake configuration

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -36,6 +36,11 @@ def getExtOrIntegerDefault(name) {
   return rootProject.ext.has(name) ? rootProject.ext.get(name) : (project.properties["Keys_" + name]).toInteger()
 }
 
+def reactNativeArchitectures() {
+    def value = project.getProperties().get("reactNativeArchitectures")
+    return value ? value.split(",") : ["armeabi-v7a", "x86", "x86_64", "arm64-v8a"]
+}
+
 def resolveReactNativeDirectory() {
   def reactNativeLocation = safeExtGet("REACT_NATIVE_NODE_MODULES_DIR", null)
   if (reactNativeLocation != null) {
@@ -103,7 +108,6 @@ if(!found) {
 def nodeModulesPath = nodeModulesDir.toString().replace("\\", "/")
 def reactNativePath = reactNativeDir.toString().replace("\\", "/")
 
-
 def supportsNamespace() {
   def parsed = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')
   def major = parsed[0].toInteger()
@@ -138,7 +142,7 @@ android {
     externalNativeBuild {
       cmake {
         cppFlags "-fexceptions", "-frtti", "-std=c++1y", "-DONANDROID"
-        abiFilters 'x86', 'x86_64', 'armeabi-v7a', 'arm64-v8a'
+        abiFilters (*reactNativeArchitectures())
         arguments '-DANDROID_STL=c++_shared',
           "-DNODE_MODULES_DIR=${nodeModulesPath}",
           "-DREACT_NATIVE_MINOR_VERSION=${REACT_NATIVE_MINOR_VERSION}"


### PR DESCRIPTION
This commit updates the build.gradle file to dynamically determine ABI filters
based on project requirements. Instead of relying on static ABI configurations,
the `reactNativeArchitectures()` function is introduced to fetch ABI filters from
project properties or default to a standard set when not specified. This ensures
that only the necessary ABIs are processed during the build, addressing issues
related to incorrect ABI configurations.

Changes include:
- Introduced `reactNativeArchitectures()` function to fetch ABI filters dynamically.
- Updated `cmake` block in build.gradle to use `abiFilters (*reactNativeArchitectures())`.

This resolves issues where CMake attempted to build unnecessary ABIs, improving
build efficiency and reliability.

To test this change:
1. Ensure your development environment has React Native dependencies installed and configured.
2. Run the project build with various Android ABIs (e.g., armeabi-v7a, arm64-v8a, x86, x86_64) using different build configurations (debug and release).
3. Verify that the build process completes successfully without attempting to build unsupported architectures and that the correct ABI is selected based on the project's configuration. Pay special attention to scenarios involving `--active-arch` to ensure correct ABI detection.
