### PR TITLE
Fixed the react-native path verification for react native v0.80.1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -83,9 +83,13 @@ if (nodeModulesDir.toFile().exists() && reactNativeDir.toFile().exists()) {
 if(!found){
   // Node's module resolution algorithm searches up to the root directory,
   // after which the base path will be null
+
+  //Hey folks, just a heads-up — starting from React Native 0.71, the /android folder is no longer included in the NPM package due to size limitations. This was further removed completely in 0.80.1, which is now causing issues with resolving paths that depended on it.
+  //As a workaround, we're now checking for the react-native/gradle folder instead. That should keep things working across newer versions.
+
   while (basePath) {
     nodeModulesDir = Paths.get(basePath.toString(), "node_modules")
-    reactNativeDir = Paths.get(nodeModulesDir.toString(), "react-native/android")
+    reactNativeDir = Paths.get(nodeModulesDir.toString(), "react-native/gradle")
     if (nodeModulesDir.toFile().exists() && reactNativeDir.toFile().exists()) {
       found = true
       break;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
Starting from React Native 0.71, the /android directory is no longer included in the React Native NPM package due to size constraints. This change was carried forward, and in React Native 0.80.1, the /android folder has been completely removed, which leads to issue of React Native npm package not being found.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

https://github.com/numandev1/react-native-keys/issues/108

## Changelog
Updated the search path for React Native from react-native/android to react-native/gradle


[CATEGORY] [TYPE] - Message

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
