### PR TITLE
chore: updated ci actions versions

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -5,18 +5,18 @@ on:
     branches:
       - master
     paths:
-      - '.github/workflows/build-android.yml'
-      - 'android/**'
-      - 'example/android/**'
-      - 'yarn.lock'
-      - 'example/yarn.lock'
+      - ".github/workflows/build-android.yml"
+      - "android/**"
+      - "example/android/**"
+      - "yarn.lock"
+      - "example/yarn.lock"
   pull_request:
     paths:
-      - '.github/workflows/build-android.yml'
-      - 'android/**'
-      - 'example/android/**'
-      - 'yarn.lock'
-      - 'example/yarn.lock'
+      - ".github/workflows/build-android.yml"
+      - "android/**"
+      - "example/android/**"
+      - "yarn.lock"
+      - "example/yarn.lock"
 
 jobs:
   build:
@@ -26,10 +26,10 @@ jobs:
       run:
         working-directory: example/android
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setup JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           java-version: 11
 
@@ -37,7 +37,7 @@ jobs:
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
       - name: Restore node_modules from cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         id: yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
@@ -48,7 +48,7 @@ jobs:
         run: yarn install --frozen-lockfile --cwd ..
 
       - name: Restore Gradle cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -5,16 +5,16 @@ on:
     branches:
       - master
     paths:
-      - '.github/workflows/build-ios.yml'
-      - 'ios/**'
-      - '*.podspec'
-      - 'example/ios/**'
+      - ".github/workflows/build-ios.yml"
+      - "ios/**"
+      - "*.podspec"
+      - "example/ios/**"
   pull_request:
     paths:
-      - '.github/workflows/build-ios.yml'
-      - 'ios/**'
-      - '*.podspec'
-      - 'example/ios/**'
+      - ".github/workflows/build-ios.yml"
+      - "ios/**"
+      - "*.podspec"
+      - "example/ios/**"
 
 jobs:
   build:
@@ -24,13 +24,13 @@ jobs:
       run:
         working-directory: example/ios
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
       - name: Restore node_modules from cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         id: yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
@@ -48,7 +48,7 @@ jobs:
           working-directory: example/ios
 
       - name: Restore Pods cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             example/ios/Pods

--- a/.github/workflows/publishnpm.yml
+++ b/.github/workflows/publishnpm.yml
@@ -4,23 +4,23 @@ on:
   workflow_dispatch:
     inputs:
       Environment:
-        description: 'Enter Anything'
+        description: "Enter Anything"
         required: false
-        default: ''
+        default: ""
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 12
       - run: yarn install
       - name: "Automated Version Bump"
         uses: "phips28/gh-action-bump-version@master"
         with:
-          tag-prefix: ''
+          tag-prefix: ""
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: JS-DevTools/npm-publish@v1

--- a/.github/workflows/validate-android.yml
+++ b/.github/workflows/validate-android.yml
@@ -5,14 +5,14 @@ on:
     branches:
       - master
     paths:
-      - '.github/workflows/validate-android.yml'
-      - 'android/**'
-      - '.editorconfig'
+      - ".github/workflows/validate-android.yml"
+      - "android/**"
+      - ".editorconfig"
   pull_request:
     paths:
-      - '.github/workflows/validate-android.yml'
-      - 'android/**'
-      - '.editorconfig'
+      - ".github/workflows/validate-android.yml"
+      - "android/**"
+      - ".editorconfig"
 
 jobs:
   lint:
@@ -22,9 +22,9 @@ jobs:
       run:
         working-directory: ./android
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           java-version: 1.8
 
@@ -32,7 +32,7 @@ jobs:
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
       - name: Restore node_modules from cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         id: yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
@@ -43,7 +43,7 @@ jobs:
         run: yarn install --frozen-lockfile --cwd ..
 
       - name: Restore Gradle cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches

--- a/.github/workflows/validate-js.yml
+++ b/.github/workflows/validate-js.yml
@@ -33,7 +33,7 @@ jobs:
     name: Compile JS (tsc)
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Install reviewdog
       uses: reviewdog/action-setup@v1
@@ -42,7 +42,7 @@ jobs:
       id: yarn-cache-dir-path
       run: echo "::set-output name=dir::$(yarn cache dir)"
     - name: Restore node_modules from cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       id: yarn-cache
       with:
         path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
@@ -64,13 +64,13 @@ jobs:
     name: Lint JS (eslint, prettier)
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Get yarn cache directory path
       id: yarn-cache-dir-path
       run: echo "::set-output name=dir::$(yarn cache dir)"
     - name: Restore node_modules from cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       id: yarn-cache
       with:
         path: ${{ steps.yarn-cache-dir-path.outputs.dir }}


### PR DESCRIPTION
There are PRs test checks failing, due to outdated actions versions, this attempts to fix that.