### PR TITLE
fix: 🐛 Check if a path(basePath) exists on Android, RN >= 0.80

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -93,7 +93,7 @@ if(!found){
   // after which the base path will be null
   while (basePath) {
     nodeModulesDir = Paths.get(basePath.toString(), "node_modules")
-    reactNativeDir = Paths.get(nodeModulesDir.toString(), "react-native/android")
+    reactNativeDir = Paths.get(nodeModulesDir.toString(), "react-native/ReactAndroid")
     if (nodeModulesDir.toFile().exists() && reactNativeDir.toFile().exists()) {
       found = true
       break;


### PR DESCRIPTION


## Summary

Because RN >= 0.80 has extracted the example out of the core

## Changelog


## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
